### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,7 @@ services:
     region: ohio
     maxmemoryPolicy: noeviction
     ipAllowList: []
+    autoDeploy: false
 
   # Let's create our background worker
   - type: worker
@@ -13,6 +14,7 @@ services:
     region: ohio
     buildCommand: bundle install
     startCommand: bundle exec sidekiq -r ./main.rb
+    autoDeploy: false
     envVars:
       - key: REDIS_URL
         fromService:
@@ -27,6 +29,7 @@ services:
     region: ohio
     buildCommand: bundle install
     startCommand: bundle exec ruby main.rb
+    autoDeploy: false
     envVars:
       - key: REDIS_URL
         fromService:


### PR DESCRIPTION
By setting `autoDeploy: false` in the the `render.yaml`, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See [the Render docs](https://render.com/docs/deploy-to-render) for more information.

Signed-off-by: zach wick <zach@render.com>