### PR TITLE
remove autoDeploy from redis service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,6 @@ services:
     region: ohio
     maxmemoryPolicy: noeviction
     ipAllowList: []
-    autoDeploy: false
 
   # Let's create our background worker
   - type: worker


### PR DESCRIPTION
This blueprint was failing to deploy with `autoDeploy: false` set for Redis. 

<img width="613" alt="Screen Shot 2022-09-29 at 12 18 39 PM" src="https://user-images.githubusercontent.com/4720963/193122873-cbd9b2fe-610a-4bc0-8bae-4788aebe67c4.png">

Removing this line fixed the deploy.